### PR TITLE
Fix RuntimeError

### DIFF
--- a/tiktok.py
+++ b/tiktok.py
@@ -169,7 +169,7 @@ class zefoy:
             except selenium.common.exceptions.NoSuchElementException:
                 pass
 
-
-obj = zefoy()
-obj.main()
-input()
+if __name__ == "__main__":
+    obj = zefoy()
+    obj.main()
+    input()


### PR DESCRIPTION
The current code triggers this exception from multiprocessing on 3.10:

```
File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/spawn.py", line 134, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

Wrapping in some __name\_\_ boilerplate fixes the problem